### PR TITLE
fix auth

### DIFF
--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -293,7 +293,6 @@ export class AuthService {
    */
   static async signInWithGoogle(): Promise<User> {
     const redirectTo = AuthSession.makeRedirectUri({
-      scheme: 'com.unify.team',
       path: 'auth/callback',
     });
 
@@ -301,20 +300,12 @@ export class AuthService {
       provider: 'google',
       options: {
         redirectTo,
-        queryParams: {
-          access_type: 'offline',
-          prompt: 'consent',
-        },
+        skipBrowserRedirect: true, // Empêche Supabase d'ouvrir le navigateur lui-même, on gère avec WebBrowser
       },
     });
 
-    if (error) {
-      throw error;
-    }
-
-    if (!data.url) {
-      throw new Error('Aucune URL retournée par Supabase');
-    }
+    if (error) throw error;
+    if (!data.url) throw new Error('Aucune URL retournée par Supabase');
 
     const result = await WebBrowser.openAuthSessionAsync(
       data.url,
@@ -322,25 +313,35 @@ export class AuthService {
     );
 
     if (result.type !== 'success') {
-      throw new Error('L\'utilisateur a annulé l\'authentification');
+      throw new Error('L\'utilisateur a annulé l\'authentification ou l\'URL n\'a pas été interceptée correctement.');
     }
 
-    const url = new URL(result.url);
-    const code = url.searchParams.get('code');
-
-    if (!code) {
-      throw new Error('Code d\'authentification non trouvé dans l\'URL');
+    // Extraction robuste de l'URL sans utiliser l'objet global URL (buggy sur RN)
+    const returnUrl = result.url;
+    
+    // Supabase ajoute souvent les paramètres en fragment (hash #) ou en query (?)
+    const urlParamsStr = returnUrl.includes('#') ? returnUrl.split('#')[1] : returnUrl.split('?')[1];
+    if (!urlParamsStr) {
+       throw new Error('Paramètres d\'authentification manquants dans l\'URL de retour.');
     }
 
-    const { data: sessionData, error: sessionError } = await supabase.auth.exchangeCodeForSession(code);
+    // Parser les paramètres
+    const params = new URLSearchParams(urlParamsStr);
+    const access_token = params.get('access_token');
+    const refresh_token = params.get('refresh_token');
 
-    if (sessionError) {
-      throw sessionError;
+    if (!access_token || !refresh_token) {
+       throw new Error('Token d\'authentification non trouvé dans l\'URL. (Redirect URL potentiellement mal configurée)');
     }
 
-    if (!sessionData.user) {
-      throw new Error('Aucun utilisateur retourné après l\'authentification');
-    }
+    // Établir manuellement la session avec Supabase
+    const { data: sessionData, error: sessionError } = await supabase.auth.setSession({
+      access_token,
+      refresh_token
+    });
+
+    if (sessionError) throw sessionError;
+    if (!sessionData.user) throw new Error('Aucun utilisateur retourné après l\'authentification');
 
     const userEmail = sessionData.user.email || '';
     const userName = sessionData.user.user_metadata?.full_name ||


### PR DESCRIPTION
This pull request refactors the Google sign-in flow in the `AuthService` to improve reliability and handle token extraction more robustly, especially for React Native environments. The main changes involve switching from exchanging an authorization code to directly handling access and refresh tokens from the redirect URL, and updating session establishment logic.

Improvements to authentication flow:

* Changed the Google sign-in method to use `skipBrowserRedirect` and handle the browser session manually, preventing Supabase from opening the browser itself. (`src/services/AuthService.ts`, [src/services/AuthService.tsL296-R344](diffhunk://#diff-55724aa12fb4317ad9c8c6f88e882e64fe9960b5a594f51bb850a3bc31d539a9L296-R344))
* Refactored the extraction of authentication tokens from the redirect URL to handle both query and fragment parameters, improving compatibility with React Native and avoiding the use of the global `URL` object. (`src/services/AuthService.ts`, [src/services/AuthService.tsL296-R344](diffhunk://#diff-55724aa12fb4317ad9c8c6f88e882e64fe9960b5a594f51bb850a3bc31d539a9L296-R344))
* Updated session establishment to use `supabase.auth.setSession` with extracted `access_token` and `refresh_token`, instead of exchanging an authorization code. (`src/services/AuthService.ts`, [src/services/AuthService.tsL296-R344](diffhunk://#diff-55724aa12fb4317ad9c8c6f88e882e64fe9960b5a594f51bb850a3bc31d539a9L296-R344))

Error handling enhancements:

* Improved error messages and checks for missing tokens and parameters in the redirect URL, providing clearer feedback for misconfiguration or user cancellation. (`src/services/AuthService.ts`, [src/services/AuthService.tsL296-R344](diffhunk://#diff-55724aa12fb4317ad9c8c6f88e882e64fe9960b5a594f51bb850a3bc31d539a9L296-R344))